### PR TITLE
[isacov] Connection of the RVFI Agent instruction monitor to the ISACOV monitor for CVE2's #226

### DIFF
--- a/env/uvme/cov/uvme_cv32e20_cov_model.sv
+++ b/env/uvme/cov/uvme_cv32e20_cov_model.sv
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
 // 
+// Copyright (c) 2025 Eclipse Foundation
 // Copyright 2022 OpenHW Group
 // Copyright 2020 Datum Technology Corporation
 // 
@@ -30,9 +31,9 @@ class uvme_cv32e20_cov_model_c extends uvm_component;
    uvme_cv32e20_cfg_c    cfg;
    uvme_cv32e20_cntxt_c  cntxt;
 
-   uvme_rv32isa_covg   isa_covg;   
-   uvme_interrupt_covg interrupt_covg;
-   uvme_debug_covg debug_covg;
+   uvme_rv32isa_covg     isa_covg;
+   uvme_interrupt_covg   interrupt_covg;
+   uvme_debug_covg       debug_covg;
 
    `uvm_component_utils_begin(uvme_cv32e20_cov_model_c)
       `uvm_field_object(cfg  , UVM_DEFAULT)

--- a/env/uvme/uvme_cv32e20_cfg.sv
+++ b/env/uvme/uvme_cv32e20_cfg.sv
@@ -34,6 +34,7 @@ class uvme_cv32e20_cfg_c extends uvma_core_cntrl_cfg_c;
    rand longint unsigned fetch_initial_delay;
 
    // Agent cfg handles
+   rand uvma_isacov_cfg_c     isacov_cfg;
    rand uvma_clknrst_cfg_c    clknrst_cfg;
    rand uvma_interrupt_cfg_c  interrupt_cfg;
    rand uvma_debug_cfg_c      debug_cfg;
@@ -65,6 +66,7 @@ class uvme_cv32e20_cfg_c extends uvma_core_cntrl_cfg_c;
       `uvm_field_int (                         sys_clk_period            , UVM_DEFAULT + UVM_DEC)
       //`uvm_field_int (                         debug_clk_period            , UVM_DEFAULT + UVM_DEC)
 
+      `uvm_field_object(isacov_cfg          , UVM_DEFAULT)
       `uvm_field_object(clknrst_cfg         , UVM_DEFAULT)
       `uvm_field_object(interrupt_cfg       , UVM_DEFAULT)
       `uvm_field_object(debug_cfg           , UVM_DEFAULT)
@@ -220,10 +222,20 @@ constraint cve2_riscv_cons {
       soft obi_memory_data_cfg.drv_slv_rvalid_random_latency_max <= 3;
       soft obi_memory_data_cfg.drv_slv_rvalid_fixed_latency      <= 3;
 
+      isacov_cfg.enabled                    == 1;
+      isacov_cfg.seq_instr_group_x2_enabled == 1;
+      isacov_cfg.seq_instr_group_x3_enabled == 1;
+      isacov_cfg.seq_instr_group_x4_enabled == 0;
+      isacov_cfg.seq_instr_x2_enabled       == 1;
+      isacov_cfg.reg_crosses_enabled        == 0;
+      isacov_cfg.reg_hazards_enabled        == 1;
+      // isacov_cfg.decoder                    == ISA_SUPPORT;
+
       rvfi_cfg.nret                      == 1;
       unified_traps                      == 1;
 
       if (is_active == UVM_ACTIVE) {
+         isacov_cfg.is_active            == UVM_PASSIVE;
          clknrst_cfg.is_active           == UVM_ACTIVE;
          interrupt_cfg.is_active         == UVM_ACTIVE;
          debug_cfg.is_active             == UVM_ACTIVE;
@@ -235,12 +247,17 @@ constraint cve2_riscv_cons {
          clknrst_cfg.trn_log_enabled           == 1;
          interrupt_cfg.trn_log_enabled         == 1;
          debug_cfg.trn_log_enabled             == 1;
+         isacov_cfg.trn_log_enabled            == 0;
          obi_memory_instr_cfg.trn_log_enabled  == 1;
          obi_memory_data_cfg.trn_log_enabled   == 1;
          rvfi_cfg.trn_log_enabled              == 1;
       }
+      else{
+         isacov_cfg.trn_log_enabled            == 0;
+      }
 
       if (cov_model_enabled) {
+         isacov_cfg.cov_model_enabled            == 1;
          obi_memory_instr_cfg.cov_model_enabled  == 1;
          obi_memory_data_cfg.cov_model_enabled   == 1;
       }
@@ -268,6 +285,7 @@ function uvme_cv32e20_cfg_c::new(string name="uvme_cv32e20_cfg");
    super.new(name);
 
    core_name             = "cve2";
+   isacov_cfg           = uvma_isacov_cfg_c::type_id::create("isacov_cfg");
    clknrst_cfg           = uvma_clknrst_cfg_c   ::type_id::create("clknrst_cfg"         );
    interrupt_cfg         = uvma_interrupt_cfg_c ::type_id::create("interrupt_cfg"       );
    debug_cfg             = uvma_debug_cfg_c     ::type_id::create("debug_cfg"           );
@@ -276,6 +294,7 @@ function uvme_cv32e20_cfg_c::new(string name="uvme_cv32e20_cfg");
 
    rvfi_cfg              = uvma_rvfi_cfg_c#(ILEN,XLEN)::type_id::create("rvfi_cfg");
 
+   isacov_cfg.core_cfg = this;
    rvfi_cfg.core_cfg = this;
 
 endfunction : new

--- a/env/uvme/uvme_cv32e20_cfg.sv
+++ b/env/uvme/uvme_cv32e20_cfg.sv
@@ -1,4 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+//
+// Copyright (c) 2025 Eclipse Foundation
 // Copyright 2020,2022 OpenHW Group
 // Copyright 2020 Datum Technology Corporation
 // Copyright 2020 Silicon Labs, Inc.
@@ -229,7 +231,6 @@ constraint cve2_riscv_cons {
       isacov_cfg.seq_instr_x2_enabled       == 1;
       isacov_cfg.reg_crosses_enabled        == 0;
       isacov_cfg.reg_hazards_enabled        == 1;
-      // isacov_cfg.decoder                    == ISA_SUPPORT;
 
       rvfi_cfg.nret                      == 1;
       unified_traps                      == 1;
@@ -247,7 +248,7 @@ constraint cve2_riscv_cons {
          clknrst_cfg.trn_log_enabled           == 1;
          interrupt_cfg.trn_log_enabled         == 1;
          debug_cfg.trn_log_enabled             == 1;
-         isacov_cfg.trn_log_enabled            == 0;
+         isacov_cfg.trn_log_enabled            == 1;
          obi_memory_instr_cfg.trn_log_enabled  == 1;
          obi_memory_data_cfg.trn_log_enabled   == 1;
          rvfi_cfg.trn_log_enabled              == 1;

--- a/env/uvme/uvme_cv32e20_env.sv
+++ b/env/uvme/uvme_cv32e20_env.sv
@@ -1,4 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+//
+// Copyright (c) 2025 Eclipse Foundation
 // Copyright 2020,2022 OpenHW Group
 // Copyright 2020 Datum Technology Corporation
 // Copyright 2020 Silicon Labs, Inc.
@@ -223,8 +225,9 @@ function void uvme_cv32e20_env_c::connect_phase(uvm_phase phase);
       if (cfg.is_active) begin
          assemble_vsequencer();
       end
-
+      
       if (cfg.cov_model_enabled) begin
+         `uvm_info(this.get_type_name(), "Connecting coverage model", UVM_LOW)
          connect_coverage_model();
       end
    end
@@ -477,17 +480,9 @@ endfunction: connect_scoreboard
 
 
 function void uvme_cv32e20_env_c::connect_coverage_model();
-   // isacov_agent.monitor.ap.connect(cov_model.exceptions_covg.isacov_mon_export);
-   // isacov_agent.monitor.ap.connect(cov_model.counters_covg.isacov_mon_export);
-   // isacov_agent.monitor.ap.connect(cov_model.interrupt_covg.isacov_mon_export);
-   // isacov_agent.monitor.ap.connect(cov_model.clic_covg.isacov_mon_export);
 
    interrupt_agent.monitor.ap_iss.connect(cov_model.interrupt_covg.interrupt_mon_export);
-   // foreach (rvfi_agent.instr_mon_ap[i]) begin
-   //    rvfi_agent.instr_mon_ap[i].connect(isacov_agent.monitor.rvfi_instr_imp);
-   //    rvfi_agent.instr_mon_ap[i].connect(cov_model.interrupt_covg.interrupt_mon_export);
-   //    rvfi_agent.instr_mon_ap[i].connect(cov_model.clic_covg.clic_mon_export);
-   // end
+   rvfi_agent.instr_monitor.ap.connect(isacov_agent.monitor.rvfi_instr_imp);
 
 endfunction: connect_coverage_model
 

--- a/env/uvme/uvme_cv32e20_env.sv
+++ b/env/uvme/uvme_cv32e20_env.sv
@@ -45,14 +45,14 @@ class uvme_cv32e20_env_c extends uvm_env;
    uvme_cv32e20_vsqr_c       vsequencer;
 
    // Agents
-   uvma_clknrst_agent_c     clknrst_agent;
-   uvma_interrupt_agent_c   interrupt_agent;
-   uvma_debug_agent_c       debug_agent;
-   uvma_obi_memory_agent_c  obi_memory_instr_agent;
-   uvma_obi_memory_agent_c  obi_memory_data_agent;
-   uvma_cv32e20_core_cntrl_agent_c core_cntrl_agent;
-
-   uvma_rvfi_agent_c#(ILEN,XLEN)      rvfi_agent;
+   uvma_cv32e20_core_cntrl_agent_c  core_cntrl_agent;
+   uvma_isacov_agent_c#(ILEN,XLEN)  isacov_agent;
+   uvma_clknrst_agent_c             clknrst_agent;
+   uvma_interrupt_agent_c           interrupt_agent;
+   uvma_debug_agent_c               debug_agent;
+   uvma_obi_memory_agent_c          obi_memory_instr_agent;
+   uvma_obi_memory_agent_c          obi_memory_data_agent;
+   uvma_rvfi_agent_c#(ILEN,XLEN)    rvfi_agent;
 
    uvmc_rvfi_reference_model reference_model;
 
@@ -387,19 +387,20 @@ endfunction: retrieve_vifs
 
 function void uvme_cv32e20_env_c::assign_cfg();
 
-   uvm_config_db#(uvme_cv32e20_cfg_c)  ::set(this, "*",                       "cfg", cfg);
-   uvm_config_db#(uvma_clknrst_cfg_c)   ::set(this, "*clknrst_agent",         "cfg", cfg.clknrst_cfg);
-   uvm_config_db#(uvma_interrupt_cfg_c) ::set(this, "*interrupt_agent",       "cfg", cfg.interrupt_cfg);
-   uvm_config_db#(uvma_debug_cfg_c)     ::set(this, "debug_agent",            "cfg", cfg.debug_cfg);
-   uvm_config_db#(uvma_obi_memory_cfg_c)::set(this, "obi_memory_instr_agent", "cfg", cfg.obi_memory_instr_cfg);
-   uvm_config_db#(uvma_obi_memory_cfg_c)::set(this, "obi_memory_data_agent",  "cfg", cfg.obi_memory_data_cfg);
+   uvm_config_db#(uvme_cv32e20_cfg_c)           ::set(this, "*",                      "cfg", cfg);
+   uvm_config_db#(uvma_clknrst_cfg_c)           ::set(this, "*clknrst_agent",         "cfg", cfg.clknrst_cfg);
+   uvm_config_db#(uvma_interrupt_cfg_c)         ::set(this, "*interrupt_agent",       "cfg", cfg.interrupt_cfg);
+   uvm_config_db#(uvma_debug_cfg_c)             ::set(this, "debug_agent",            "cfg", cfg.debug_cfg);
+   uvm_config_db#(uvma_obi_memory_cfg_c)        ::set(this, "obi_memory_instr_agent", "cfg", cfg.obi_memory_instr_cfg);
+   uvm_config_db#(uvma_obi_memory_cfg_c)        ::set(this, "obi_memory_data_agent",  "cfg", cfg.obi_memory_data_cfg);
 
-   uvm_config_db#(uvma_core_cntrl_cfg_c)::set(this, "core_cntrl_agent",       "cfg", cfg);
-   uvm_config_db#(uvma_rvfi_cfg_c#(ILEN,XLEN))::set(this, "*rvfi_agent",      "cfg", cfg.rvfi_cfg);
+   uvm_config_db#(uvma_core_cntrl_cfg_c)        ::set(this, "core_cntrl_agent",       "cfg", cfg);
+   uvm_config_db#(uvma_isacov_cfg_c)            ::set(this, "*isacov_agent",          "cfg", cfg.isacov_cfg);
+   uvm_config_db#(uvma_rvfi_cfg_c#(ILEN,XLEN))  ::set(this, "*rvfi_agent",            "cfg", cfg.rvfi_cfg);
 
    if (cfg.scoreboard_enabled) begin
-      uvm_config_db#(uvma_core_cntrl_cfg_c)::set(this, "reference_model", "cfg", cfg);
-      uvm_config_db#(uvma_core_cntrl_cfg_c)::set(this, "*m_rvfi_scoreboard", "cfg", cfg);
+      uvm_config_db#(uvma_core_cntrl_cfg_c)     ::set(this, "reference_model", "cfg", cfg);
+      uvm_config_db#(uvma_core_cntrl_cfg_c)     ::set(this, "*m_rvfi_scoreboard", "cfg", cfg);
    end
 
 endfunction: assign_cfg
@@ -419,14 +420,15 @@ endfunction: assign_cntxt
 
 
 function void uvme_cv32e20_env_c::create_agents();
-
-   clknrst_agent           = uvma_clknrst_agent_c   ::type_id::create("clknrst_agent",          this);
-   interrupt_agent         = uvma_interrupt_agent_c ::type_id::create("interrupt_agent",        this);
-   debug_agent             = uvma_debug_agent_c     ::type_id::create("debug_agent",            this);
-   obi_memory_instr_agent  = uvma_obi_memory_agent_c::type_id::create("obi_memory_instr_agent", this);
-   obi_memory_data_agent   = uvma_obi_memory_agent_c::type_id::create("obi_memory_data_agent",  this);
-   rvfi_agent              = uvma_rvfi_agent_c#(ILEN,XLEN)::type_id::create("rvfi_agent",       this);
-   core_cntrl_agent        = uvma_cv32e20_core_cntrl_agent_c::type_id::create("core_cntrl_agent", this);
+   
+   core_cntrl_agent       = uvma_cv32e20_core_cntrl_agent_c::type_id::create("core_cntrl_agent",       this);
+   isacov_agent           = uvma_isacov_agent_c#(ILEN,XLEN)::type_id::create("isacov_agent",           this);
+   clknrst_agent          = uvma_clknrst_agent_c           ::type_id::create("clknrst_agent",          this);
+   interrupt_agent        = uvma_interrupt_agent_c         ::type_id::create("interrupt_agent",        this);
+   debug_agent            = uvma_debug_agent_c             ::type_id::create("debug_agent",            this);
+   obi_memory_instr_agent = uvma_obi_memory_agent_c        ::type_id::create("obi_memory_instr_agent", this);
+   obi_memory_data_agent  = uvma_obi_memory_agent_c        ::type_id::create("obi_memory_data_agent",  this);
+   rvfi_agent             = uvma_rvfi_agent_c#(ILEN,XLEN)  ::type_id::create("rvfi_agent",             this);
 
 endfunction: create_agents
 
@@ -475,8 +477,17 @@ endfunction: connect_scoreboard
 
 
 function void uvme_cv32e20_env_c::connect_coverage_model();
+   // isacov_agent.monitor.ap.connect(cov_model.exceptions_covg.isacov_mon_export);
+   // isacov_agent.monitor.ap.connect(cov_model.counters_covg.isacov_mon_export);
+   // isacov_agent.monitor.ap.connect(cov_model.interrupt_covg.isacov_mon_export);
+   // isacov_agent.monitor.ap.connect(cov_model.clic_covg.isacov_mon_export);
 
    interrupt_agent.monitor.ap_iss.connect(cov_model.interrupt_covg.interrupt_mon_export);
+   // foreach (rvfi_agent.instr_mon_ap[i]) begin
+   //    rvfi_agent.instr_mon_ap[i].connect(isacov_agent.monitor.rvfi_instr_imp);
+   //    rvfi_agent.instr_mon_ap[i].connect(cov_model.interrupt_covg.interrupt_mon_export);
+   //    rvfi_agent.instr_mon_ap[i].connect(cov_model.clic_covg.clic_mon_export);
+   // end
 
 endfunction: connect_coverage_model
 

--- a/env/uvme/uvme_cv32e20_pkg.sv
+++ b/env/uvme/uvme_cv32e20_pkg.sv
@@ -47,6 +47,7 @@ package uvme_cv32e20_pkg;
    import uvml_mem_pkg       ::*;
 
    import uvma_core_cntrl_pkg::*;
+   import uvma_isacov_pkg::*;
    import uvma_rvfi_pkg::*;
    import uvmc_rvfi_scoreboard_pkg::*;
    import uvmc_rvfi_reference_model_pkg::*;

--- a/sim/ExternalRepos.mk
+++ b/sim/ExternalRepos.mk
@@ -12,7 +12,7 @@ export SHELL = /bin/bash
 
 CV_CORE_REPO   ?= https://github.com/openhwgroup/cve2
 CV_CORE_BRANCH ?= main
-CV_CORE_HASH   ?= ca6bc06
+CV_CORE_HASH   ?= 8d4cf8b
 
 CV_VERIF_REPO   ?= https://github.com/MikeOpenHWGroup/core-v-verif
 CV_VERIF_BRANCH ?= no_spike

--- a/tb/uvmt/uvmt_cv32e20.flist
+++ b/tb/uvmt/uvmt_cv32e20.flist
@@ -30,6 +30,7 @@
 -f ${DV_UVMA_DEBUG_PATH}/uvma_debug_pkg.flist
 -f ${DV_UVMA_CORE_CNTRL_PATH}/uvma_core_cntrl_pkg.flist
 -f ${DV_UVMA_RVFI_PATH}/uvma_rvfi_pkg.flist
+-f ${DV_UVMA_ISACOV_PATH}/uvma_isacov_pkg.flist
 -f ${DV_UVMC_RVFI_REFERENCE_MODEL_PATH}/uvmc_rvfi_reference_model_pkg.flist
 -f ${DV_UVMC_RVFI_SCOREBOARD_PATH}/uvmc_rvfi_scoreboard_pkg.flist
 

--- a/tb/uvmt/uvmt_cv32e20_tb.sv
+++ b/tb/uvmt/uvmt_cv32e20_tb.sv
@@ -1,5 +1,5 @@
 //
-// Copyright 2020,2022 OpenHW Group
+// Copyright 2020, 2022, 2025 OpenHW Group
 // Copyright 2020 Datum Technology Corporation
 // Copyright 2020 Silicon Labs, Inc.
 //
@@ -272,7 +272,7 @@ module uvmt_cv32e20_tb;
   //        endcase
   //    end
   //  end
-  // // End of ISS WRAPPER instanitation and step-and-compare logic.
+  // // End of ISS WRAPPER instantiation and step-and-compare logic.
   /////////////////////////////////////////////////////////////////////////////
 
    // Informational print message on loading of OVPSIM ISS to benchmark some elf image loading times

--- a/tb/uvmt/uvmt_cv32e20_tb.sv
+++ b/tb/uvmt/uvmt_cv32e20_tb.sv
@@ -1,5 +1,6 @@
 //
-// Copyright 2020, 2022, 2025 OpenHW Group
+// Copyright (c) 2025 Eclipse Foundation
+// Copyright 2020,2022 OpenHW Group
 // Copyright 2020 Datum Technology Corporation
 // Copyright 2020 Silicon Labs, Inc.
 //


### PR DESCRIPTION
This PR intends to implement task [#226 of CVE2](https://github.com/openhwgroup/cve2/issues/226). To do so:

- It enables the usage of the ISACOV (uvme_rv32isa_covg), activating its transaction log under the configuration of the environment.
- It connects the RVFI Agent instruction monitor to send instructions to the ISACOV monitor, on the environment file.
- Add the necessary files and includes to use the ISACOV.

Additionally:
- Update the reference CVE2 core repo to the latest.
- Added copyright disclaimer of this year to the modified files, fixed some typos...

To test it, I also changed [CORE-V-VERIF's 77d47dd](https://github.com/MikeOpenHWGroup/core-v-verif/blob/77d47dd97a78ec5d93f8ab51e546e7697e9f144d/lib/uvm_agents/uvma_rvfi/uvma_rvfi_cfg.sv#L90) `vendor_lib/openhwgroup_core-v-verif/lib/uvm_agents/uvma_rvfi/uvma_rvfi_cfg.sv` locally  by enabling `ap_write_en`, otherwise the RVFI instructions monitor does not send data to the analysis port ( [[1]](https://github.com/MikeOpenHWGroup/core-v-verif/blob/77d47dd97a78ec5d93f8ab51e546e7697e9f144d/lib/uvm_agents/uvma_rvfi/uvma_rvfi_instr_mon.sv#L133) [[2]](https://github.com/MikeOpenHWGroup/core-v-verif/blob/77d47dd97a78ec5d93f8ab51e546e7697e9f144d/lib/uvm_agents/uvma_rvfi/uvma_rvfi_instr_mon.sv#L294)).

