### PR TITLE
Addition of the WRITE_RVI_AP runtime option to enable the write to the RVFI monitor analysis port, required for CVE2 #226

### DIFF
--- a/mk/uvmt/dsim.mk
+++ b/mk/uvmt/dsim.mk
@@ -46,6 +46,10 @@ else
     DSIM_RUN_FLAGS += +DISABLE_OVPSIM
 endif
 
+ifeq ($(WRITE_RVFI_AP),YES)
+    DSIM_RUN_FLAGS += +WRITE_RVFI_AP
+endif
+
 ifeq ($(call IS_YES,$(SPIKE)),YES)
     DSIM_RUN_FLAGS += +SPIKE
 endif

--- a/sim/ExternalRepos.mk
+++ b/sim/ExternalRepos.mk
@@ -14,9 +14,9 @@ CV_CORE_REPO   ?= https://github.com/openhwgroup/cve2
 CV_CORE_BRANCH ?= main
 CV_CORE_HASH   ?= 8d4cf8b
 
-CV_VERIF_REPO   ?= https://github.com/MikeOpenHWGroup/core-v-verif
-CV_VERIF_BRANCH ?= no_spike
-CV_VERIF_HASH   ?= 77d47dd
+CV_VERIF_REPO   ?= https://github.com/cairo-caplan/core-v-verif.git
+CV_VERIF_BRANCH ?= no_spike_cv32e20
+CV_VERIF_HASH   ?= aea9fc8
 
 RISCVDV_REPO    ?= https://github.com/google/riscv-dv
 RISCVDV_BRANCH  ?= master


### PR DESCRIPTION
I added the runtime option `WRITE_RVFI_AP` to the Makefile of the UVM simulation for the DSIM simulator. It controls the writing of instructions to the analysis port of the RVFI instruction monitor ([line 295 of CORE-V-VERIF no_spike `uvma_rvfi_instr_mon.sv`](https://github.com/cairo-caplan/core-v-verif/blob/aea9fc89f41f2b0ac585445934c9e6779ba8afbb/lib/uvm_agents/uvma_rvfi/uvma_rvfi_instr_mon.sv#L295)), that feeds the [ISACOV agent monitor](https://github.com/MikeOpenHWGroup/cv32e20-dv/blob/ca6a32fc20b3fc9c2a6076ad3a114b838c05739c/env/uvme/uvme_cv32e20_env.sv#L485).

You can test it, for example, by running:

```
cd sim/uvmt/
make test TEST=hello-world SIMULATOR=dsim USE_ISS=NO WRITE_RVFI_AP=YES
# Check if the instructions are logged on dsim_results/default/hello-world/0/uvm_test_top.env.isacov_agent.trn.log
make clean
make test TEST=hello-world SIMULATOR=dsim USE_ISS=NO WRITE_RVFI_AP=NO
# Check if dsim_results/default/hello-world/0/uvm_test_top.env.isacov_agent.trn.log is empty
```
<br>

However, there are some caveats of this PR that makes this solution non-ideal or temporary:

1. The current version of the [MikeOpenHWGroup/cv32e20-dv top-e20-dv branch](https://github.com/MikeOpenHWGroup/cv32e20-dv/blob/ca6a32fc20b3fc9c2a6076ad3a114b838c05739c/sim/ExternalRepos.mk#L19) uses [MikeOpenHWGroup/core-v-verif  no_spike 77d47dd](https://github.com/MikeOpenHWGroup/core-v-verif/commit/77d47dd97a78ec5d93f8ab51e546e7697e9f144d), as an external dependency. To make this `WRITE_RVFI_AP` option effective, a modification of CORE-V-VERIF `uvm_rvfi_cfg.sv` was necessary, as explained on [CVE2's #226](https://github.com/MikeOpenHWGroup/cv32e20-dv/pull/2#issue-3255703208).

2. After making the [necessary modification to CORE-V-VERIF `uvm_rvfi_cfg.sv`](https://github.com/cairo-caplan/core-v-verif/commit/aea9fc89f41f2b0ac585445934c9e6779ba8afbb), where `soft ap_write_en == ($test$plusargs("WRITE_RVFI_AP"))`, I noticed I could not push it to [MikeOpenHWGroup/core-v-verif no_spike](https://github.com/MikeOpenHWGroup/core-v-verif/commits/no_spike) because there is a newer commit, hash [1fe10f8 "Update RVFI agent to match version used by e40x"](https://github.com/MikeOpenHWGroup/core-v-verif/commit/1fe10f87b45b445322c4b378b7f6f80efd3867aa) with considerable changes. Such changes include the removal of `soft ap_write_en` from `uvm_rvfi_cfg.sv`, plus, at its current state, it does not work with the current [MikeOpenHWGroup/cv32e20-dv top-e20-dv](https://github.com/MikeOpenHWGroup/cv32e20-dv/tree/top-e20-dv).

3. As a result, I created a personal fork of [MikeOpenHWGroup/core-v-verif  no_spike 77d47dd](https://github.com/MikeOpenHWGroup/core-v-verif/commit/77d47dd97a78ec5d93f8ab51e546e7697e9f144d) named [no_spike_cv32e20](https://github.com/cairo-caplan/core-v-verif/tree/no_spike_cv32e20), to which I pushed the [modification to  `uvm_rvfi_cfg.sv` `soft ap_write_en == ($test$plusargs("WRITE_RVFI_AP"))`.](https://github.com/cairo-caplan/core-v-verif/commit/aea9fc89f41f2b0ac585445934c9e6779ba8afbb). 
This is the core-v-verif dependency I use on this PR.


Finally, I have to check what is necessary to make the latest [MikeOpenHWGroup/core-v-verif no_spike](https://github.com/MikeOpenHWGroup/core-v-verif/commits/no_spike) to work with `[this branch of the cv32e20-dv](https://github.com/MikeOpenHWGroup/cv32e20-dv)`, and merge it with mine [no_spike_cv32e20](https://github.com/cairo-caplan/core-v-verif/tree/no_spike_cv32e20).

