### PR TITLE
Fix debug memory region allocation in core testbench

### DIFF
--- a/tb/core/cv32e20_tb_wrapper.sv
+++ b/tb/core/cv32e20_tb_wrapper.sv
@@ -20,10 +20,16 @@ module cv32e20_tb_wrapper
     #(parameter // Parameters used by TB
                 INSTR_RDATA_WIDTH = 32,
                 RAM_ADDR_WIDTH    = 20,
+                // Parameters used by DUT
                 BOOT_ADDR         = 'h80,
                 DM_HALTADDRESS    = 32'h1A11_0800,
+                // Debug-exception entry address driven to the core's
+                // dm_exception_addr_i.  Must match _debugger_exception_start in
+                // bsp/link.ld (0x1A14_0000).  Previously this connected to an
+                // *undeclared* identifier (DM_EXCEPTIONADDRESS), which Verilator
+                // implicitly tied to 0 -- sending in-debug exceptions to PC 0.
+                DM_EXCEPTIONADDRESS = 32'h1A14_0000,
                 HART_ID           = 32'h0000_0000,
-                // Parameters used by DUT
                 MHPMCounterNum    = 10,
                 MHPMCounterWidth  = 40,
                 RV32E             = 1'b0,
@@ -112,13 +118,12 @@ module cv32e20_tb_wrapper
 
          .debug_req_i            ( debug_req             ),
          .dm_halt_addr_i         ( DM_HALTADDRESS        ),
-	 .dm_exception_addr_i    ( DM_EXCEPTIONADDRESS   ),
+         .dm_exception_addr_i    ( DM_EXCEPTIONADDRESS   ),
          .crash_dump_o           (                       ),
 
          // CPU Control Signals
          .fetch_enable_i         ( fetch_enable_i        ),
          .core_sleep_o           (                       )
-	 
        );
 
     // this handles read to RAM and memory mapped pseudo peripherals
@@ -131,9 +136,12 @@ module cv32e20_tb_wrapper
          .dm_halt_addr_i ( DM_HALTADDRESS                            ),
 
          .instr_req_i    ( instr_req                                 ),
-         .instr_addr_i   ( { {10{1'b0}},
-                             instr_addr[RAM_ADDR_WIDTH-1:0]
-                           }                                         ),
+         // Pass the FULL instruction address: mm_ram needs the upper bits to
+         // detect and remap the debugger region (DM_HALTADDRESS .. ).  Truncating
+         // to RAM_ADDR_WIDTH here (as was previously done) stripped the 0x1A11_xxxx
+         // /0x1A14_xxxx tags so debug fetches missed the remap and read low RAM.
+         // (The data port already passes the full address -- see data_addr_i.)
+         .instr_addr_i   ( instr_addr                                ),
          .instr_rdata_o  ( instr_rdata                               ),
          .instr_rvalid_o ( instr_rvalid                              ),
          .instr_gnt_o    ( instr_gnt                                 ),

--- a/tb/core/mm_ram.sv
+++ b/tb/core/mm_ram.sv
@@ -2,7 +2,7 @@
 //
 // Copyright 2025 OpenHW Foundation
 // SPDX-License-Identifier: Apache-2.0 WITH SHL-0.51
-// 
+//
 // Copyright 2017 Embecosm Limited <www.embecosm.com>
 // Copyright and related rights are licensed under the Solderpad Hardware
 // License, Version 0.51 (the "License"); you may not use this file except in
@@ -26,9 +26,14 @@ module mm_ram
      parameter RAM_ADDR_WIDTH    =  16,
                INSTR_RDATA_WIDTH = 128, // width of read_data on instruction bus
                DATA_RDATA_WIDTH  =  32, // width of read_data on data bus
-               DBG_ADDR_WIDTH    =  14, // POT ammount of memory allocated for debugger
+               IRQ_WIDTH         =  32, // IRQ vector width
+               DBG_ADDR_WIDTH    =  18  // POT amount of memory allocated for debugger
+                                        // 2**18 = 0x40000 covers the full span of the
+                                        // debugger sections (.debugger @0x1A110800 through
+                                        // .debugger_stack ending ~0x1A1400E0, span 0x2F8E0).
+                                        // NOTE: must match the value used by the program
+                                        // loader in tb_top.sv.
                                         // physically located at end of memory
-               IRQ_WIDTH         =  32  // IRQ vector width
   )
   (
      input logic                          clk_i,

--- a/tb/core/tb_top.sv
+++ b/tb/core/tb_top.sv
@@ -1,5 +1,5 @@
 // Top level testbench for the CV32E20
-// 
+//
 // Copyright 2025 Eclipse Foundation
 // SPDX-License-Identifier: Apache-2.0 WITH SHL-0.51
 //
@@ -19,16 +19,31 @@
 
 `timescale 1ns/100ps
 
-module tb_top
-    #(parameter INSTR_RDATA_WIDTH = 32,
-      parameter RAM_ADDR_WIDTH    = 22,
-      parameter BOOT_ADDR         = 'h4000 // must be 256-byte aligned; raised from 'h2000 to satisfy .align 14 in I-jal test
-     );
+module tb_top;
 
     const int CLK_PHASE_HI        = 5;
     const int CLK_PHASE_LO        = 5;
     const int CLK2NRESET_DELAY    = 1;
     const int RESET_ASSERT_CYCLES = 4;
+
+    // top-level localparams to be passed down to all submodules
+    localparam int          INSTR_RDATA_WIDTH   = 32;
+    localparam int          RAM_ADDR_WIDTH      = 22;
+    localparam int          DBG_ADDR_WIDTH      = 18;
+    // The boot-address of the CVE2 must be 256-byte aligned and must match start of text block in bsp/link.ld
+    // Raised from 'h2000 to satisfy .align 14 in I-jal test (ACT4)
+    localparam logic [31:0] BOOT_ADDR           = 'h4000; // must be 256-byte aligned; raised from 'h2000 to satisfy .align 14 in I-jal test (ACT4)
+    // Debugger memory remap parameters.  The debugger sections are linked at
+    // high addresses (.debugger @0x1A11_0800, .debugger_exception/.stack
+    // @0x1A14_0000) that lie far outside the RAM array.  mm_ram remaps run-time
+    // accesses in the window [DM_HALTADDRESS, DM_HALTADDRESS + 2**DBG_ADDR_WIDTH)
+    // to the top of RAM; the program loader below must apply the identical
+    // remap so the loaded image matches what the core fetches/accesses.
+    // NOTE: DM_HALTADDRESS and DBG_ADDR_WIDTH must match mm_ram.
+    // TODO: clean up memory model in testbench to eliminate the need to remap debug memory region.
+    localparam logic [31:0] DM_HALTADDRESS      = 32'h1A11_0800;  // must match .debugger in bsp/link.ld
+    localparam logic [31:0] DM_EXCEPTIONADDRESS = 32'h1A14_0000;  // must match .debugger_exception in bsp/link.ld
+
 
     // clock and reset for tb
     logic                   core_clk;
@@ -59,16 +74,58 @@ module tb_top
         end
     end
 
-    // we either load the provided firmware or execute a small test program that
-    // doesn't do more than an infinite loop with some I/O
+    // Remap a byte address exactly as mm_ram does (see instr_addr_remap and
+    // setup_transaction in mm_ram.sv).  Debug-window addresses are relocated to
+    // the top of RAM; all others are truncated to the RAM array width.
+    // TODO: clean up memory model in testbench to eliminate the need to remap debug memory region.
+    function automatic int unsigned remap_load_addr(input logic [31:0] a);
+        if ((a >= DM_HALTADDRESS) && (a < (DM_HALTADDRESS + (1 << DBG_ADDR_WIDTH))))
+            remap_load_addr = (a - DM_HALTADDRESS) + (1 << RAM_ADDR_WIDTH) - (1 << DBG_ADDR_WIDTH);
+        else
+            remap_load_addr = a & ((1 << RAM_ADDR_WIDTH) - 1);
+    endfunction
+
+    // Load the provided firmware (Verilog-hex from objcopy -O verilog).  A plain
+    // $readmemh cannot be used because it writes the file's absolute addresses
+    // directly into the array and aborts on the out-of-bounds debugger sections.
+    // Instead we parse the hex ourselves and apply the debug-region remap.
     initial begin: load_prog
         automatic string test_program;
-        automatic int prog_size = 6;
+        int          fd;
+        string       tok;
+        logic [31:0] cur_addr;
+        logic [31:0] byte_val;
+        int          n_bytes;
 
         if($value$plusargs("test_program=%s", test_program)) begin
             if($test$plusargs("verbose"))
                 $display("[%s] @ t=%0t: loading test-program %0s", id, $time, test_program);
-            $readmemh(test_program, cv32e20_tb_wrapper_inst.mm_ram_inst.dp_ram_inst.mem);
+
+            fd = $fopen(test_program, "r");
+            if (fd == 0) begin
+                $display("[%s] @ t=%0t: ERROR: cannot open test-program %0s", id, $time, test_program);
+                $fatal(2);
+            end
+
+            cur_addr = '0;
+            n_bytes  = 0;
+            // Read whitespace-separated tokens: "@<hex>" sets the byte address,
+            // every other token is one hex byte written at the (remapped) address.
+            while ($fscanf(fd, "%s", tok) == 1) begin
+                if (tok.getc(0) == "@") begin
+                    void'($sscanf(tok, "@%h", cur_addr));
+                end else begin
+                    void'($sscanf(tok, "%h", byte_val));
+                    cv32e20_tb_wrapper_inst.mm_ram_inst.dp_ram_inst.mem[remap_load_addr(cur_addr)] = byte_val[7:0];
+                    cur_addr = cur_addr + 1;
+                    n_bytes  = n_bytes + 1;
+                end
+            end
+            $fclose(fd);
+
+            if($test$plusargs("verbose"))
+                $display("[%s] @ t=%0t: loaded %0d bytes (debug region remapped to top of RAM)",
+                         id, $time, n_bytes);
         end else begin
             $display("[%s] @ t=%0t: No test_program specified... terminating.", id, $time);
             end_of_sim();
@@ -163,24 +220,25 @@ module tb_top
 
     final begin
         if (wave_file != "") begin
-	    $display("[%s] @ t=%0t: waves written to %s", id, $time, wave_file);
-	end
-	$display("\n[%s] @ t=%0t: Verilator simulation ending...", id, $time);
+            $display("[%s] @ t=%0t: waves written to %s", id, $time, wave_file);
+        end
+        $display("\n[%s] @ t=%0t: Verilator simulation ending...", id, $time);
     end
 
     // wrapper for cv32e20, the memory and virtual peripherals.
     cv32e20_tb_wrapper
         #(
           // Parameters used by TB
-          .INSTR_RDATA_WIDTH (INSTR_RDATA_WIDTH),
-          .RAM_ADDR_WIDTH    (RAM_ADDR_WIDTH),
-          .BOOT_ADDR         (BOOT_ADDR),
-          .DM_HALTADDRESS    (32'h1A11_0800),
+          .INSTR_RDATA_WIDTH   (INSTR_RDATA_WIDTH),
+          .RAM_ADDR_WIDTH      (RAM_ADDR_WIDTH),
           // Parameters used by DUT
-          .MHPMCounterNum    (10),
-          .MHPMCounterWidth  (40),
-          .RV32E             (1'b0),
-          .RV32M             (2/*RV32MFast*/)
+          .BOOT_ADDR           (BOOT_ADDR),
+          .DM_HALTADDRESS      (DM_HALTADDRESS),
+          .DM_EXCEPTIONADDRESS (DM_EXCEPTIONADDRESS),
+          .MHPMCounterNum      (10),
+          .MHPMCounterWidth    (40),
+          .RV32E               (1'b0),
+          .RV32M               (2/*RV32MFast*/)
          )
     cv32e20_tb_wrapper_inst
         (

--- a/tests/programs/custom/debug_test/debug_test.c
+++ b/tests/programs/custom/debug_test/debug_test.c
@@ -22,6 +22,8 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include <unistd.h>
+
 volatile int glb_hart_status  = 0; // Written by main code only, read by debug code
 volatile int glb_debug_status = 0; // Written by debug code only, read by main code
 volatile int glb_ebreak_status = 0; // Written by ebreak code only, read by main code


### PR DESCRIPTION
## Description
The goal of this PR is to merge in an update to the core testbench to add a hack to the `dp_ram` model that remaps the location of the debug and debug exception handlers into the region defined by the linker control script (`bsp/link.ld`).

## Changes
See comments in `tb/core/tb_top.sv`, `tb/core/cv32e20_tb_wrapper.sv` and `tb/core/mm_ram.sv`.

## Verification
The test-programs with no asynchronous code paths (such as `hello-world`, `riscv_arithmetic_base_test_0`, etc.) have been run to demonstrate they are unaffected by this PR.  The `debug_test` now compiles and runs as expected up to "Test 17".
